### PR TITLE
Allows negative indexes in line assertions

### DIFF
--- a/src/assert_line.bash
+++ b/src/assert_line.bash
@@ -137,7 +137,7 @@ assert_line() {
   while (( $# > 0 )); do
     case "$1" in
     -n|--index)
-      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+      if (( $# < 2 )) || ! [[ $2 =~ ^-?([0-9]|[1-9][0-9]+)$ ]]; then
         echo "\`--index' requires an integer argument: \`$2'" \
         | batslib_decorate 'ERROR: assert_line' \
         | fail

--- a/src/refute_line.bash
+++ b/src/refute_line.bash
@@ -140,7 +140,7 @@ refute_line() {
   while (( $# > 0 )); do
     case "$1" in
     -n|--index)
-      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+      if (( $# < 2 )) || ! [[ $2 =~ ^-?([0-9]|[1-9][0-9]+)$ ]]; then
         echo "\`--index' requires an integer argument: \`$2'" \
         | batslib_decorate 'ERROR: refute_line' \
         | fail


### PR DESCRIPTION
It is easier to match the last line of the output with:

```
assert_line -n -1 'text'
```

than:

```
assert_line -n 13 'text'
```

The preceding text may also change and a standard count from the top may not be possible.