### PR TITLE
Provides more flexible loading of bats-support

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,8 @@
+export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/.."
+export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
+
 # Load dependencies.
-load "${BATS_TEST_DIRNAME}/../node_modules/bats-support/load.bash"
+load "${TEST_DEPS_DIR}/bats-support/load.bash"
 
 # Load library.
 load '../load'


### PR DESCRIPTION
This moves the bats-support loading to a method used in bats-file providing for a more reliable test run by users.

It should fix my problem in #34. 