### PR TITLE
Redirect all links to bats-core forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,6 @@ An error is displayed when used simultaneously.
 
 [bats]: https://github.com/bats-core/bats-core
 [bash-comp-cmd]: https://www.gnu.org/software/bash/manual/bash.html#Compound-Commands
-[bats-docs]: https://github.com/ztombol/bats-docs
-[bats-support-output]: https://github.com/ztombol/bats-support#output-formatting
-[bats-support]: https://github.com/ztombol/bats-support
+[bats-docs]: https://bats-core.readthedocs.io/
+[bats-support-output]: https://github.com/bats-core/bats-support#output-formatting
+[bats-support]: https://github.com/bats-core/bats-support


### PR DESCRIPTION
It's confusing to have the links lead to the `ztombol` versions of the
repositories and the docs link is also old.

I also assume fixing the links will eventually fix the google results to
point to the new home for these repos vs. the original locations.