### PR TITLE
Add support for 'assert_not_equal'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This project provides the following functions:
 
  - [assert](#assert) / [refute](#refute) Assert a given expression evaluates to `true` or `false`.
  - [assert_equal](#assert_equal) Assert two parameters are equal.
+ - [assert_not_equal](#assert_not_equal) Assert two parameters are not equal.
  - [assert_success](#assert_success) / [assert_failure](#assert_failure) Assert exit status is `0` or `1`.
  - [assert_output](#assert_output) / [refute_output](#refute_output) Assert output does (or does not) contain given content.
  - [assert_line](#assert_line) / [refute_line](#refute_line) Assert a specific line of output does (or does not) contain given content.
@@ -121,6 +122,28 @@ On failure, the expected and actual values are displayed.
 -- values do not equal --
 expected : want
 actual   : have
+--
+```
+
+If either value is longer than one line both are displayed in *multi-line* format.
+
+
+### `assert_not_equal`
+
+Fail if the two parameters, actual and unexpected value respectively, are equal.
+
+```bash
+@test 'assert_not_equal()' {
+  assert_not_equal 'foobar' 'foobar'
+}
+```
+
+On failure, the expected and actual values are displayed.
+
+```
+-- values should not be equal --
+unexpected : foobar
+actual     : foobar
 --
 ```
 

--- a/load.bash
+++ b/load.bash
@@ -22,6 +22,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/refute.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert_equal.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/src/assert_not_equal.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert_success.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert_failure.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert_output.bash"

--- a/src/assert_not_equal.bash
+++ b/src/assert_not_equal.bash
@@ -1,0 +1,42 @@
+# assert_not_equal
+# ============
+#
+# Summary: Fail if the actual and unexpected values are equal.
+#
+# Usage: assert_not_equal <actual> <unexpected>
+#
+# Options:
+#   <actual>      The value being compared.
+#   <unexpected>  The value to compare against.
+#
+#   ```bash
+#   @test 'assert_not_equal()' {
+#     assert_not_equal 'foo' 'foo'
+#   }
+#   ```
+#
+# IO:
+#   STDERR - expected and actual values, on failure
+# Globals:
+#   none
+# Returns:
+#   0 - if actual does not equal unexpected
+#   1 - otherwise
+#
+# On failure, the unexpected and actual values are displayed.
+#
+#   ```
+#   -- values should not be equal --
+#   unexpected : foo
+#   actual     : foo
+#   --
+#   ```
+assert_not_equal() {
+  if [[ "$1" == "$2" ]]; then
+    batslib_print_kv_single_or_multi 10 \
+    'unexpected' "$2" \
+    'actual'     "$1" \
+    | batslib_decorate 'values should not be equal' \
+    | fail
+  fi
+}

--- a/test/assert_not_equal.bats
+++ b/test/assert_not_equal.bats
@@ -13,6 +13,7 @@ load test_helper
   assert_test_pass
 
   run assert_not_equal "" "foo"
+  assert_test_pass
 }
 
 @test 'assert_not_equal() <actual> <unexpected>: returns 1 and displays details if <actual> equals <unexpected>' {

--- a/test/assert_not_equal.bats
+++ b/test/assert_not_equal.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'assert_not_equal() <actual> <unexpected>: returns 0 if <actual> does not equal <unexpected>' {
+  run assert_not_equal foo bar
+  assert_test_pass
+
+  run assert_not_equal "foo" "bar"
+  assert_test_pass
+
+  run assert_not_equal "foo" ""
+  assert_test_pass
+
+  run assert_not_equal "" "foo"
+}
+
+@test 'assert_not_equal() <actual> <unexpected>: returns 1 and displays details if <actual> equals <unexpected>' {
+  run assert_not_equal 'foobar' 'foobar'
+  assert_test_fail <<'ERR_MSG'
+
+-- values should not be equal --
+unexpected : foobar
+actual     : foobar
+--
+ERR_MSG
+
+  run assert_not_equal 1 1
+  assert_test_fail <<'ERR_MSG'
+
+-- values should not be equal --
+unexpected : 1
+actual     : 1
+--
+ERR_MSG
+}
+
+@test 'assert_not_equal() <actual> <unexpected>: displays details in multi-line format if <actual> and <unexpected> are longer than one line' {
+  run assert_not_equal $'foo\nbar' $'foo\nbar'
+  assert_test_fail <<'ERR_MSG'
+
+-- values should not be equal --
+unexpected (2 lines):
+  foo
+  bar
+actual (2 lines):
+  foo
+  bar
+--
+ERR_MSG
+}
+
+@test 'assert_not_equal() <actual> <unexpected>: performs literal matching' {
+    run assert_not_equal 'a' '*'
+    assert_test_pass
+}


### PR DESCRIPTION
This is essentially a copy/paste of `assert_equal`. However, unlike `assert_equal`, I think it's more correct to perform the equivalence test surrounding each operand in double quotes (see [assert_equal.bash#35](https://github.com/bats-core/bats-assert/blob/master/src/assert_equal.bash#L35) vs [assert_not_equal.bash#35](https://github.com/bats-core/bats-assert/blob/38bfbf61443c046acf91b678a5a8eb5a0ab13000/src/assert_not_equal.bash#L35)).

This would also close #31 .