### PR TITLE
Fix: First two examples are backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Fail if the given expression evaluates to false.
 
 ```bash
 @test 'assert()' {
-  rm -f '/var/log/test.log'
-  assert [ -e '/var/log/test.log' ]
+  assert [ 1 -lt 0 ]
 }
 ```
 
@@ -77,7 +76,7 @@ On failure, the failed expression is displayed.
 
 ```
 -- assertion failed --
-expression : [ -e /var/log/test.log ]
+expression : [ 1 -lt 0 ]
 --
 ```
 
@@ -92,8 +91,7 @@ Fail if the given expression evaluates to true.
 
 ```bash
 @test 'refute()' {
-  touch '/var/log/test.log'
-  refute [ -e '/var/log/test.log' ]
+  refute [ 1 -gt 0 ]
 }
 ```
 
@@ -101,7 +99,7 @@ On failure, the successful expression is displayed.
 
 ```
 -- assertion succeeded, but it was expected to fail --
-expression : [ -e /var/log/test.log ]
+expression : [ 1 -gt 0 ]
 --
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Fail if the given expression evaluates to false.
 
 ```bash
 @test 'assert()' {
-  touch '/var/log/test.log'
+  rm -f '/var/log/test.log'
   assert [ -e '/var/log/test.log' ]
 }
 ```
@@ -92,7 +92,7 @@ Fail if the given expression evaluates to true.
 
 ```bash
 @test 'refute()' {
-  rm -f '/var/log/test.log'
+  touch '/var/log/test.log'
   refute [ -e '/var/log/test.log' ]
 }
 ```


### PR DESCRIPTION
The file must be removed for `assert` to fail, as shown in the example. The file must exist for `refute` to fail.