### PR TITLE
test/test_helper.bash: Use bats_load_library to load bats-support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      BATS_LIB_PATH: /usr/lib/npm/node_modules
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -23,5 +24,5 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - run: npm install
+    - run: npm install --loglevel verbose
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+  workflow_dispatch:
   pull_request:
     branches: [ master ]
 
@@ -13,8 +13,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      BATS_LIB_PATH: /usr/lib/npm/node_modules
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -24,5 +22,5 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - run: npm install --loglevel verbose
-    - run: npm test
+    - run: npm install
+    - run: BATS_LIB_PATH="$PWD/node_modules" npm test

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,5 @@
 # Load dependencies.
-load "${BATS_TEST_DIRNAME}/../node_modules/bats-support/load.bash"
+bats_load_library 'bats-support'
 
 # Load library.
 load '../load'


### PR DESCRIPTION
Instead of hard-coding `node_modules` in the path (source of various issues: #38, #34), use the `bats_load_library` command to load `bats-support`.

`bats_load_library` is available since Bats v1.6.

Tested by running `bats test` on a Debian system with the `bats-support` package installed.