### PR TITLE
assert_regex: matching empty string is not invalid regex

### DIFF
--- a/src/assert_regex.bash
+++ b/src/assert_regex.bash
@@ -36,7 +36,7 @@ assert_regex() {
 	local -r value="${1}"
 	local -r pattern="${2}"
 
-	if [[ '' =~ ${pattern} ]] || (( ${?} == 2 )); then
+	if [[ '' =~ ${pattern} ]]; (( ${?} == 2 )); then
 		echo "Invalid extended regular expression: \`${pattern}'" \
 		| batslib_decorate 'ERROR: assert_regex' \
 		| fail

--- a/test/assert_regex.bats
+++ b/test/assert_regex.bats
@@ -80,3 +80,8 @@ Invalid extended regular expression: `[.*'
 --
 ERR_MSG
 }
+
+@test "assert_regex allows regex matching empty string (see #53)" {
+  run assert_regex any_value '.*'
+  assert_success
+}


### PR DESCRIPTION
Fixes #53 