### PR TITLE
Remove accidental(?) dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "assert",
     "assertion",
     "helper"
-  ],
-  "dependencies": {
-    "verbose": "^0.2.3"
-  }
+  ]
 }


### PR DESCRIPTION
I assume this 'verbose' dep was accidental? It doesn't make sense for any of the bats packages to have any actual deps because they wouldn't/couldn't be "required" anyway.