### PR TITLE
readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ refute_line -- '--'
 
 Fail if the given expression evaluates to false.
 
-> _**Note**
+> _**Note**:
 > The expression must be a simple command.
 > [Compound commands][bash-comp-cmd], such as `[[`, can be used only when executed with `bash -c`._
 
@@ -294,7 +294,7 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, the assertion fails if the *extended regular expression* does not match `$output`.
 
-> _**Note**
+> _**Note**:
 > The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively._
 
 ```bash
@@ -411,7 +411,7 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, the assertion fails if the *extended regular expression* matches `$output`.
 
-> _**Note**
+> _**Note**:
 > The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively._
 
 ```bash
@@ -459,8 +459,9 @@ It checks that the expected line appears in the output (default) or in a specifi
 Matching can be literal (default), partial or regular expression.
 This function is the logical complement of `refute_line`.
 
-***Warning:***
-*Due to a [bug in Bats][bats-93], empty lines are discarded from `${lines[@]}`, causing line indices to change and preventing testing for empty lines.*
+> _**Warning**:
+> Due to a [bug in Bats][bats-93], empty lines are discarded from `${lines[@]}`,
+> causing line indices to change and preventing testing for empty lines._
 
 [bats-93]: https://github.com/sstephenson/bats/pull/93
 
@@ -478,7 +479,7 @@ The assertion fails if the expected line is not found in `${lines[@]}`.
 
 On failure, the expected line and the output are displayed.
 
-> _**Warning**
+> _**Warning**:
 > The output displayed does not contain empty lines.
 > See the Warning above for more._
 
@@ -548,7 +549,7 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, a match fails if the *extended regular expression* does not match the line being tested.
 
-> _**Note**
+> _**Note**: 
 > As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively._
 
 ```bash
@@ -581,7 +582,7 @@ It checks that the unexpected line does not appear in the output (default) or in
 Matching can be literal (default), partial or regular expression.
 This function is the logical complement of `assert_line`.
 
-> _**Warning**
+> _**Warning**:
 > Due to a [bug in Bats][bats-93], empty lines are discarded from `${lines[@]}`, 
 > causing line indices to change and preventing testing for empty lines._
 
@@ -601,7 +602,7 @@ The assertion fails if the unexpected line is found in `${lines[@]}`.
 
 On failure, the unexpected line, the index of its first match and the output with the matching line highlighted are displayed.
 
-> _**Warning**
+> _**Warning**:
 > The output displayed does not contain empty lines.
 > See the Warning above for more._
 
@@ -673,7 +674,7 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, a match fails if the *extended regular expression* matches the line being tested.
 
-> _**Note**
+> _**Note**:
 > As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively._
 
 ```bash
@@ -730,7 +731,7 @@ An error is displayed if the specified extended regular expression is invalid.
 For description of the matching behavior, refer to the documentation of the
 `=~` operator in the [Bash manual][bash-conditional].
 
-> _**Note**
+> _**Note**:
 > the `BASH_REMATCH` array is available immediately after the assertion succeeds but is fragile;
 > i.e. prone to being overwritten as a side effect of other actions._
 
@@ -770,7 +771,7 @@ An error is displayed if the specified extended regular expression is invalid.
 For description of the matching behavior, refer to the documentation of the
 `=~` operator in the [Bash manual][bash-conditional].
 
-> _**Note**
+> _**Note**:
 > the `BASH_REMATCH` array is available immediately after the assertion fails but is fragile;
 > i.e. prone to being overwritten as a side effect of other actions like calling `run`.
 > Thus, it's good practice to avoid using `BASH_REMATCH` in conjunction with `refute_regex()`.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ refute_line -- '--'
 
 Fail if the given expression evaluates to false.
 
-***Note:***
-*The expression must be a simple command.
-[Compound commands][bash-comp-cmd], such as `[[`, can be used only when executed with `bash -c`.*
+> _**Note**
+> The expression must be a simple command.
+> [Compound commands][bash-comp-cmd], such as `[[`, can be used only when executed with `bash -c`._
 
 ```bash
 @test 'assert()' {
@@ -86,9 +86,9 @@ expression : [ 1 -lt 0 ]
 
 Fail if the given expression evaluates to true.
 
-***Note:***
-*The expression must be a simple command.
-[Compound commands][bash-comp-cmd], such as `[[`, can be used only when executed with `bash -c`.*
+> _**Note**
+> The expression must be a simple command.
+> [Compound commands][bash-comp-cmd], such as `[[`, can be used only when executed with `bash -c`._
 
 ```bash
 @test 'refute()' {
@@ -294,7 +294,8 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, the assertion fails if the *extended regular expression* does not match `$output`.
 
-*Note: The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively.*
+> _**Note**
+> The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively._
 
 ```bash
 @test 'assert_output() regular expression matching' {
@@ -410,7 +411,8 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, the assertion fails if the *extended regular expression* matches `$output`.
 
-*Note: The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively.*
+> _**Note**
+> The anchors `^` and `$` bind to the beginning and the end of the entire output (not individual lines), respectively._
 
 ```bash
 @test 'refute_output() regular expression matching' {
@@ -476,9 +478,9 @@ The assertion fails if the expected line is not found in `${lines[@]}`.
 
 On failure, the expected line and the output are displayed.
 
-***Warning:***
-*The output displayed does not contain empty lines.
-See the Warning above for more.*
+> _**Warning**
+> The output displayed does not contain empty lines.
+> See the Warning above for more._
 
 ```
 -- output does not contain line --
@@ -546,7 +548,8 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, a match fails if the *extended regular expression* does not match the line being tested.
 
-*Note: As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively.*
+> _**Note**
+> As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively._
 
 ```bash
 @test 'assert_line() regular expression matching' {
@@ -578,8 +581,9 @@ It checks that the unexpected line does not appear in the output (default) or in
 Matching can be literal (default), partial or regular expression.
 This function is the logical complement of `assert_line`.
 
-***Warning:***
-*Due to a [bug in Bats][bats-93], empty lines are discarded from `${lines[@]}`, causing line indices to change and preventing testing for empty lines.*
+> _**Warning**
+> Due to a [bug in Bats][bats-93], empty lines are discarded from `${lines[@]}`, 
+> causing line indices to change and preventing testing for empty lines._
 
 [bats-93]: https://github.com/sstephenson/bats/pull/93
 
@@ -597,9 +601,9 @@ The assertion fails if the unexpected line is found in `${lines[@]}`.
 
 On failure, the unexpected line, the index of its first match and the output with the matching line highlighted are displayed.
 
-***Warning:***
-*The output displayed does not contain empty lines.
-See the Warning above for more.*
+> _**Warning**
+> The output displayed does not contain empty lines.
+> See the Warning above for more._
 
 ```
 -- line should not be in output --
@@ -669,7 +673,8 @@ An error is displayed when used simultaneously.
 Regular expression matching can be enabled with the `--regexp` option (`-e` for short).
 When used, a match fails if the *extended regular expression* matches the line being tested.
 
-*Note: As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively.*
+> _**Note**
+> As expected, the anchors `^` and `$` bind to the beginning and the end of the matched line, respectively._
 
 ```bash
 @test 'refute_line() regular expression matching' {
@@ -723,11 +728,11 @@ format.
 An error is displayed if the specified extended regular expression is invalid.
 
 For description of the matching behavior, refer to the documentation of the
-`=~` operator in the
-[Bash manual]: https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html.
-Note that the `BASH_REMATCH` array is available immediately after the
-assertion succeeds but is fragile, i.e. prone to being overwritten as a side
-effect of other actions.
+`=~` operator in the [Bash manual][bash-conditional].
+
+> _**Note**
+> the `BASH_REMATCH` array is available immediately after the assertion succeeds but is fragile;
+> i.e. prone to being overwritten as a side effect of other actions._
 
 ### `refute_regex`
 
@@ -763,20 +768,20 @@ If the value or pattern is longer than one line then it is displayed in
 An error is displayed if the specified extended regular expression is invalid.
 
 For description of the matching behavior, refer to the documentation of the
-`=~` operator in the
-[Bash manual]: https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html.
+`=~` operator in the [Bash manual][bash-conditional].
 
-Note that the `BASH_REMATCH` array is available immediately after the assertion
-fails but is fragile, i.e. prone to being overwritten as a side effect of other
-actions like calling `run`. Thus, it's good practice to avoid using
-`BASH_REMATCH` in conjunction with `refute_regex()`. The valuable information
-the array contains is the matching part of the value which is printed in the
-failing test log, as mentioned above.
+> _**Note**
+> the `BASH_REMATCH` array is available immediately after the assertion fails but is fragile;
+> i.e. prone to being overwritten as a side effect of other actions like calling `run`.
+> Thus, it's good practice to avoid using `BASH_REMATCH` in conjunction with `refute_regex()`.
+> The valuable information the array contains is the matching part of the value which is printed in the failing test log, as mentioned above._
 
 <!-- REFERENCES -->
 
 [bats]: https://github.com/bats-core/bats-core
 [bash-comp-cmd]: https://www.gnu.org/software/bash/manual/bash.html#Compound-Commands
+[bash-conditional]: https://www.gnu.org/software/bash/manual/bash.html#Conditional-Constructs
+
 [bats-docs]: https://bats-core.readthedocs.io/
 [bats-support-output]: https://github.com/bats-core/bats-support#output-formatting
 [bats-support]: https://github.com/bats-core/bats-support


### PR DESCRIPTION
Leverage github's new rendering for blockquoted notes and warnings.

blockquoted notes render as:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/119972/220807805-6b626d09-e61f-4557-b705-6288f951f58d.png">

and warnings: 
<img width="234" alt="image" src="https://user-images.githubusercontent.com/119972/220807855-44d260d2-36c0-4392-8006-8e965c5a1623.png">

AFAICT, for the nice rendering to work, it must be:
1. blockquoted (prefixed with `>`)
2. Note/Warning must be precisely titlecased, bold and without punctuation (colon may follow but may not be within the bold markers)

I'm ambivalent about whether the notes and warnings read better as italics or not. They were italicized before, so I left them. Though they weren't "blockquoted" before, which has its own styling that probably makes the italics unnecessary? 🤷 

Also fixed up a couple broken reference links