### PR TITLE
Rename master branch as main

### DIFF
--- a/.github/workflows/sync-master.yml
+++ b/.github/workflows/sync-master.yml
@@ -1,0 +1,8 @@
+name: Sync Master
+on:
+  push: { branches: main }
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: bats-core/.github/.github/workflows/sync-master.yml@v1


### PR DESCRIPTION
I think we should move to the new default branch (`main`) instead of `master`.

If the majority of users of this repository were only _contributors_, we could rename it and run the few commands to update our clones. However, cloning this repository is also an _installation_ mechanism for many. For that reason, I don't think we can simply rename because that would "break" installations made via cloning. (It probably wouldn't break that many installs but it could leave them without the means to upgrade by pulling.)

## Proposal
Downstream clones only need a `master` branch to exist in order to continue to pull updates. It needn't actually be the default branch. So I propose that we use the workflow in this PR. It responds to push events to the `main` branch (and manual `workflow_dispatch` events, when necessary). With that workflow in place, we can rename (using github's UI to change the default branch) to `main`. We'll document (in the readme) the steps necessary to update one's default branch locally to track the new default.

Any new clones of the repo will automatically use the new `main` as default, while old clones will continue to work by pulling from the legacy master branch (kept in sync by the workflow). Over time, the number of clones still pointing to the legacy master branch should diminish and eventually we can just delete this workflow and the master branch.

- [ ] bump the .github repo's tag
- [ ] merge this PR with workflow to keep master in sync
- [ ] rename branch using github's ui
- [ ] add instructions to readme

I would then propose we follow this process for every bats-core repo still using master.