### PR TITLE
Publish to NPM registry.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release: { types: [published] }
+  workflow_dispatch:
+
+jobs:
+  npmjs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          registry-url: "https://npm.pkg.github.com"
+      - name: scope package name as required by GitHub Packages
+        run: npm init -y --scope ${{ github.repository_owner }}
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,22 @@ jobs:
   test:
     uses: bats-core/.github/.github/workflows/test.yml@v1
 
-  test-npm:
+  test-npm-install:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup NodeJs
         uses: actions/setup-node@v4
+      # Move to temp directory, and install package as a user would
+      - name: Package up project
+        run: |
+          npm pack --pack-destination ${{ runner.temp }}
       - name: Install using npm
+        working-directory: ${{ runner.temp }}
+        env:
+          BATS_LIB_PATH: ${{ github.workspace }}/node_modules
         run: |
-          npm ci ./
-      - name: Run tests
-        run: |
-          npm test
+          npm install ./bats-assert-*.tgz
+          cp -R ${{github.workspace}}/test/install ./test/
+          npx bats -r ./test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install using npm
         working-directory: ${{ runner.temp }}
         env:
-          BATS_LIB_PATH: ${{ github.workspace }}/node_modules
+          BATS_LIB_PATH: ${{ runner.temp }}/node_modules
         run: |
           npm install ./bats-assert-*.tgz
           cp -R ${{github.workspace}}/test/install ./test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,3 +7,17 @@ on:
 jobs:
   test:
     uses: bats-core/.github/.github/workflows/test.yml@v1
+
+  test-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup NodeJs
+        uses: actions/setup-node@v4
+      - name: Install using npm
+        run: |
+          npm ci ./
+      - name: Run tests
+        run: |
+          npm test

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "bats-assert",
+  "name": "@pauldruce/bats-assert",
   "version": "2.1.0",
   "description": "Common assertions for Bats",
   "homepage": "https://github.com/bats-core/bats-assert",
   "license": "CC0-1.0",
-  "author": "Zoltán Tömböl (https://github.com/ztombol)",
+  "author": "Bats-core Organization",
   "contributors": [
     "Sam Stephenson <sstephenson@gmail.com> (http://sstephenson.us/)",
     "Jason Karns <jason.karns@gmail.com> (http://jason.karns.name)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pauldruce/bats-assert",
+  "name": "bats-assert",
   "version": "2.1.0",
   "description": "Common assertions for Bats",
   "homepage": "https://github.com/bats-core/bats-assert",

--- a/package.json
+++ b/package.json
@@ -23,16 +23,13 @@
   ],
   "scripts": {
     "test": "bats ${CI+-t} test",
+    "test:install": "bats test",
     "postversion": "npm publish",
     "prepublishOnly": "npm run publish:github",
     "publish:github": "git push --follow-tags"
   },
-  "devDependencies": {
+  "dependencies": {
     "bats": "^1",
-    "bats-support": "^0.3"
-  },
-  "peerDependencies": {
-    "bats": "0.4 || ^1",
     "bats-support": "^0.3"
   },
   "keywords": [

--- a/test/install/test_npm_installation.bats
+++ b/test/install/test_npm_installation.bats
@@ -1,0 +1,9 @@
+function setup() {
+    bats_load_library bats-support
+    bats_load_library bats-assert
+}
+
+@test 'bats-assert is installed and accessible' {
+    run assert_equal 'batslib_print_kv_single' 'batslib_print_kv_single'
+    assert_success
+}


### PR DESCRIPTION
Summary of changes:
* I've added a github workflow which will publish this project as a package on npmjs and the github npm registry. 
  * This is essentially the same process that bats-core is using to publish as a node package. 
  * This requires a secret called NPM_TOKEN for the existing project to work for the npmjs registry.
  * Publishing to the GitHub npm registry should work without any extra secrets. 
* Listed bats and bats-support as actual dependencies, as bats-assert isn't much use without them. 
* A smoke test of the npm installation was added to show it works. 


This PR addressing ~#70~ : https://github.com/bats-core/bats-core/issues/1107 