### PR TITLE
feat: forward Bash 5.3's invalid regex error details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /yarn.lock
 /bats-assert-*.tgz
+test/.bats/run-logs/

--- a/src/assert_line.bash
+++ b/src/assert_line.bash
@@ -217,11 +217,8 @@ Did you mean to call \`assert_line\` or \`assert_stderr_line\`?" \
   # Arguments.
   local -r expected="$1"
 
-  if (( is_mode_regexp == 1 )) && [[ '' =~ $expected ]] || (( $? == 2 )); then
-    echo "Invalid extended regular expression: \`$expected'" \
-    | batslib_decorate "ERROR: ${caller}" \
-    | fail
-    return $?
+  if (( is_mode_regexp == 1 )) then
+    __check_is_valid_regex "$expected" "$caller" || return 1
   fi
 
   # Matching.

--- a/src/assert_output.bash
+++ b/src/assert_output.bash
@@ -218,10 +218,8 @@ Did you mean to call \`assert_output\` or \`assert_stderr\`?" |
     fi
   elif (( is_mode_regexp )); then
     # shellcheck disable=2319
-    if [[ '' =~ $expected ]] || (( $? == 2 )); then
-      echo "Invalid extended regular expression: \`$expected'" \
-      | batslib_decorate "ERROR: ${caller}" \
-      | fail
+    if ! __check_is_valid_regex "$expected" "$caller"; then
+      return 1
     elif ! [[ $stream =~ $expected ]]; then
       batslib_print_kv_single_or_multi 6 \
       'regexp'  "$expected" \

--- a/src/assert_regex.bash
+++ b/src/assert_regex.bash
@@ -36,10 +36,8 @@ assert_regex() {
 	local -r value="${1}"
 	local -r pattern="${2}"
 
-	if [[ '' =~ ${pattern} ]]; (( ${?} == 2 )); then
-		echo "Invalid extended regular expression: \`${pattern}'" \
-		| batslib_decorate 'ERROR: assert_regex' \
-		| fail
+	if ! __check_is_valid_regex "$pattern" assert_regex; then
+		return 1
 	elif ! [[ "${value}" =~ ${pattern} ]]; then
 		if shopt -p nocasematch &>/dev/null; then
 			local case_sensitive=insensitive

--- a/src/refute_output.bash
+++ b/src/refute_output.bash
@@ -204,11 +204,8 @@ __refute_stream() {
     unexpected="${1-}"
   fi
 
-  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
-    echo "Invalid extended regular expression: \`$unexpected'" \
-    | batslib_decorate "ERROR: ${caller}" \
-    | fail
-    return $?
+  if (( is_mode_regexp == 1 )); then
+    __check_is_valid_regex "$unexpected" "$caller" || return 1
   fi
 
   # Matching.

--- a/src/refute_regex.bash
+++ b/src/refute_regex.bash
@@ -45,10 +45,8 @@ refute_regex() {
 	local -r value="${1}"
 	local -r pattern="${2}"
 
-	if [[ '' =~ ${pattern} ]] || (( ${?} == 2 )); then
-		echo "Invalid extended regular expression: \`${pattern}'" \
-		| batslib_decorate 'ERROR: refute_regex' \
-		| fail
+	if ! __check_is_valid_regex "${pattern}" "${FUNCNAME[0]}"; then
+		return 1
 	elif [[ "${value}" =~ ${pattern} ]]; then
 		if shopt -p nocasematch &>/dev/null; then
 			local case_sensitive=insensitive

--- a/test/assert_line.bats
+++ b/test/assert_line.bats
@@ -336,12 +336,21 @@ ERR_MSG
 @test 'assert_line() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run assert_line --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: assert_line --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: assert_line --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 @test "assert_line(): \`--' stops parsing options" {

--- a/test/assert_output.bats
+++ b/test/assert_output.bats
@@ -254,12 +254,21 @@ ERR_MSG
 @test 'assert_output() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run assert_output --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: assert_output --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: assert_output --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 

--- a/test/assert_regex.bats
+++ b/test/assert_regex.bats
@@ -73,12 +73,21 @@ ERR_MSG
 @test "assert_regex() <value> <pattern>: returns 1 and displays an error message if <pattern> is not a valid extended regular expression" {
   run assert_regex value '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: assert_regex --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else 
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: assert_regex --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 @test "assert_regex allows regex matching empty string (see #53)" {

--- a/test/assert_stderr.bats
+++ b/test/assert_stderr.bats
@@ -267,12 +267,21 @@ ERR_MSG
 @test 'assert_stderr() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run assert_stderr --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: assert_stderr --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: assert_stderr --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 

--- a/test/assert_stderr_line.bats
+++ b/test/assert_stderr_line.bats
@@ -349,12 +349,21 @@ ERR_MSG
 @test 'assert_stderr_line() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run assert_stderr_line --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: assert_stderr_line --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: assert_stderr_line --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 @test "assert_stderr_line(): \`--' stops parsing options" {

--- a/test/refute_line.bats
+++ b/test/refute_line.bats
@@ -329,12 +329,21 @@ ERR_MSG
 @test 'refute_line() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run refute_line --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: refute_line --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: refute_line --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 @test "refute_line(): \`--' stops parsing options" {

--- a/test/refute_output.bats
+++ b/test/refute_output.bats
@@ -198,13 +198,21 @@ ERR_MSG
 # Error handling
 @test 'refute_output() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run refute_output --regexp '[.*'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
 
-  assert_test_fail <<'ERR_MSG'
+-- ERROR: refute_output --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: refute_output --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 

--- a/test/refute_regex.bats
+++ b/test/refute_regex.bats
@@ -89,10 +89,19 @@ ERR_MSG
 @test "refute_regex() <value> <pattern>: returns 1 and displays an error message if <pattern> is not a valid extended regular expression" {
   run refute_regex value '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: refute_regex --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: refute_regex --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }

--- a/test/refute_stderr.bats
+++ b/test/refute_stderr.bats
@@ -211,12 +211,21 @@ ERR_MSG
 @test 'refute_stderr() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run refute_stderr --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<'ERR_MSG'
+
+-- ERROR: refute_stderr --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: refute_stderr --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 

--- a/test/refute_stderr_line.bats
+++ b/test/refute_stderr_line.bats
@@ -341,12 +341,21 @@ ERR_MSG
 @test 'refute_stderr_line() --regexp <regexp>: returns 1 and displays an error message if <regexp> is not a valid extended regular expression' {
   run refute_stderr_line --regexp '[.*'
 
-  assert_test_fail <<'ERR_MSG'
+  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >=3) )); then
+    assert_test_fail <<"ERR_MSG"
+
+-- ERROR: refute_stderr_line --
+invalid regular expression `[.*': Missing ']'
+--
+ERR_MSG
+  else
+    assert_test_fail <<'ERR_MSG'
 
 -- ERROR: refute_stderr_line --
 Invalid extended regular expression: `[.*'
 --
 ERR_MSG
+  fi
 }
 
 @test "refute_stderr_line(): \`--' stops parsing options" {


### PR DESCRIPTION
Also fix failing tests due to additional output from Bash. This held up development in bats-core due to failing tests in via the `Dockerfile`, which is based on `bash:latest`.