### PR TITLE
fix: add permissions for job 'ossf-scorecard' in called workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,4 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     uses: bats-core/.github/.github/workflows/test.yml@v1


### PR DESCRIPTION
This adds the permisisons needed for the test to run.

## Reason:

Currently the test workflow fails instantly with:

```
 Invalid workflow file: .github/workflows/test.yml#L8
The workflow is not valid. .github/workflows/test.yml (Line: 8, Col: 3): Error calling workflow 'bats-core/.github/.github/workflows/test.yml@v1'. The nested job 'ossf-scorecard' is requesting 'security-events: write, id-token: write', but is only allowed 'security-events: none, id-token: none'.
```

The current `bats-core/.github/.github/workflows/test.yml@v1` runs tag `v1.1.0` in [bats-core/.github](https://github.com/bats-core/.github) where the job `ossf-scorecard` needs extra permissions, see [bats-core/.github/.github/workflows/test.yml:56](https://github.com/bats-core/.github/blob/aaeacee71dc3659a76bfebd852b740ab42cd3447/.github/workflows/test.yml#L56)