### PR TITLE
ci: add dependabot config for GitHub Actions and npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Changes

This adds a Dependabot config so this repo gets automated PRs for dependency updates.

Dependabot must still be enabled in this repo's settings under [Settings > Advanced Security](https://github.com/bats-core/bats-assert/settings/security_analysis) by a repository admin.

The `bats-core/.github` repo already uses Dependabot.

## Reason

This repo has an outdated dependency on bats-core `v1.9.0` in its [package-lock.json:21](https://github.com/bats-core/bats-assert/blob/697471b7a89d3ab38571f38c6c7c4b460d1f5e35/package-lock.json#L21).

The latest version of bats-core on npm is [v1.13.0](https://www.npmjs.com/package/bats), almost three years newer than `v1.9.0`.

Rather than opening a PR just to update this dependency, I think automating dependency updates is the better approach.
