### PR TITLE
ci: cancel superseded test runs with concurrency groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Group runs by workflow and PR/ref; release-triggered runs use a separate
+# `-release` suffix. Cancel an older run when a new one uses the same group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event_name == 'release' && '-release' || '' }}
+  cancel-in-progress: true
+
 jobs:
   test:
     uses: bats-core/.github/.github/workflows/test.yml@v1


### PR DESCRIPTION
Use concurrency groups based on the workflow and PR number or Git ref.
Cancel an in-progress run when a newer run uses the same group, freeing CI capacity from outdated tests.

Release events use a separate suffix to keep them distinct where applicable.