### PR TITLE
fix: make npm test portable to Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "src"
   ],
   "scripts": {
-    "test": "bats ${CI+-t} test",
+    "test": "bats test",
     "postversion": "git push --follow-tags"
   },
   "devDependencies": {


### PR DESCRIPTION
On Windows, the test command runs through two shell layers:

GitHub Actions (PowerShell)
  -> npm cit
    -> npm test (cmd.exe)
      -> bats ${CI+-t} test

cmd.exe does not understand the POSIX ${CI+-t} expansion. It passes the expression to Bats as an argument, which Bats interprets as a test path and fails before running any tests.

The expansion was added in 2019 to select TAP output in CI, but Bats has done that automatically when CI is set since 2014. Remove the redundant expansion so npm test works across platforms without changing CI output.

> This is related to [PR 15 in bats-core/.github](https://github.com/bats-core/.github/pull/15)